### PR TITLE
Pinned requests package to 2.27.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Ibrahim Ahmed",
     description="Track and visualize satellites and control antenna position",
     packages=find_packages(),
-    install_requires=['six', 'pyserial', 'requests', 'python-dateutil'],
+    install_requires=['six', 'pyserial', 'requests<=2.27.1', 'python-dateutil'],
     include_package_data = True,
 )
 


### PR DESCRIPTION
This is because requests version 2.27.1 is the latest version that supports python2. Though it might be better for the future if everything was changed to python3 instead